### PR TITLE
fix podcast link

### DIFF
--- a/episode/episode-001.md
+++ b/episode/episode-001.md
@@ -1,5 +1,6 @@
 # Episode
 - 第1回（2021/06/01）: 自己紹介
+	- link: https://anchor.fm/double-m2/episodes/1-e11od5t/a-a5n663i
 
 # Contents
 - お互いの自己紹介

--- a/episode/episode-002.md
+++ b/episode/episode-002.md
@@ -1,5 +1,6 @@
 # Episode
 - 第2回（2021/06/05）: 転職話
+	- link: https://anchor.fm/double-m2/episodes/2-e12714u/a-a5pmuv6
 
 # Contents
 - お互いの転職話


### PR DESCRIPTION
それぞれのepisodeのページにlinkがないのが不便だったのでPR出します！！！  
`twitter-->episodeページ-->linkがない...-->readmeまで見に行く`

という手順なのがもったいないです！